### PR TITLE
fix error state for legendaries page

### DIFF
--- a/general_website/static/general_website/js/bloodmallet_chart_import.js
+++ b/general_website/static/general_website/js/bloodmallet_chart_import.js
@@ -431,7 +431,7 @@ function bloodmallet_chart_import() {
     } else {
       spec_data = loaded_data[data_type][fight_style][wow_class][wow_spec];
     }
-    if (spec_data["error"] === true) {
+    if (spec_data['status'] === 'error') {
       return simulation_error(html_element, spec_data);
     } else {
       wow_class = spec_data['simc_settings']['class'];


### PR DESCRIPTION
Hi!
There seems to be an error in the field name for checking the status of the loaded data.

\* error message: "No standard chart with these values found." for castingpatchwerk/druid/balance

![Снимок экрана 2021-02-18 в 16 16 13](https://user-images.githubusercontent.com/3511312/108366130-0f2fe000-7209-11eb-8e3b-51916379ae5c.png)
